### PR TITLE
Merge arm-none-eabi-gdb-compat

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
 Copyright (c) 2016, 31i73.com, for portions of project 'atom-dbg-gdb-customer-server' originating from project 'atom-dbg-gdb'.
+
 Copyright (c) 2017, Matthew Sembinelli, for portions of project 'atom-dbg-gdb-customer-server' NOT originating from project 'atom-dbg-gdb'.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2016 31i73.com
+Copyright (c) 2016, 31i73.com, for portions of project 'atom-dbg-gdb-customer-server' originating from project 'atom-dbg-gdb'.
+Copyright (c) 2017, Matthew Sembinelli, for portions of project 'atom-dbg-gdb-customer-server' NOT originating from project 'atom-dbg-gdb'.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -38,21 +38,21 @@ For a list of features and all available keyboard shortcuts, please see [dbg](ht
 
 ## Example .atom-dbg.cson for nRF52 Embedded Target
 ```
-"out\\current\\sys.axf":
+"out\\out.axf":
 	debugger: "dbg-gdb"
 	gdb_executable: 'arm-none-eabi-gdb'
 	gdb_commands: ['target remote localhost:2331', 'monitor speed 1000',
-								 'monitor clrbp', 'monitor reset', 'monitor halt',
-								 'monitor regs', 'monitor flash breakpoints 1',
-								 'monitor semihosting enable', 'monitor semihosting IOClient 1',
-								 'monitor SWO DisableTarget 0xFFFFFFFF',
-								 'monitor SWO EnableTarget 0 0 0x1 0']
-	path: "out\\current\\sys.axf"
-	cwd: "out\\current"
+                       'monitor clrbp', 'monitor reset', 'monitor halt',
+                       'monitor regs', 'monitor flash breakpoints 1',
+                       'monitor semihosting enable', 'monitor semihosting IOClient 1',
+                       'monitor SWO DisableTarget 0xFFFFFFFF',
+                       'monitor SWO EnableTarget 0 0 0x1 0']
+	path: "out\\out.axf"
+	cwd: "out"
 	server_executable: 'JLinkGDBServerCL'
 	server_arguments: ['-if', 'swd', '-device', 'nRF52832_xxAA',
 	                '-endian', 'little', '-speed', '1000', '-port',
-									'2331', '-swoport', '2332', '-telnetport',
-									'2333', '-vd', '-ir', '-localhostonly', '1',
-									'-singlerun', '-strict', '-timeout', '0']
-````
+                        '2331', '-swoport', '2332', '-telnetport',
+                        '2333', '-vd', '-ir', '-localhostonly', '1',
+                        '-singlerun', '-strict', '-timeout', '0']
+```

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-# dbg-gdb package
+# dbg-gdb-custom-server package
 
-An interactive GDB debugger for Atom
+An interactive GDB debugger for Atom.
+
+dbg-gdb-custom-server additions:
+
+Based on dbg-gdb, but removes some of the hardcoded start commands, and provides an option for a debug server. Great for debugging remote embedded targets.
+
+Removed commands: 'set mi-async on' && 'set target-async on' as these cause problems for remote targets.
 
 ![Debug screenshot](http://i.imgur.com/XcI592U.png)
 
 ## How to use
 
 1. Right click on an executable in the treeview, select `Debug this file`, and click `Save`
-2. Toggle breakpoints by clicking beside line numbers or pressing `F9`
-3. Press `F5`, and select the executable
-4. ...
-5. Profit!
+2. (Optional) Customize the gdb_executable, gdb_arguments, server_executable, and server_arguments if your device is a remote/embedded target.
+3. Toggle breakpoints by clicking beside line numbers or pressing `F9`
+4. Press `F5`, and select the executable
+5. ...
+6. Profit!
 
 ## Service: `dbgProvider`
 
@@ -24,5 +31,7 @@ Creates a `dbgProvider` for GDB, see [basic dbgProvider  service description](ht
 > `gdb_executable` - *Optional*. The full command used to execute gdb (defaults to 'gdb')  
 > `gdb_arguments` - *Optional*. An array of extra arguments to pass to gdb (note that the arguments ['-quiet', '--interpreter=mi2'] are always included first)  
 > `gdb_commands` - *Optional*. An array of commands to pass to gdb, once active (these are executed last of all, but right before '-exec-run')  
+> `server_executable` - *Optional*. Starts a remote GDB server of your choice, ex: 'JLinkGDBServerCL')
+> `server_arguments` - *Optional*. An array of extra arguments to pass to the remote GDB server ex: ['-if', 'swd', '-device', 'nRF52832_xxAA'])
 
-For a list of features and all available keyboard shortcuts, please see [dbg](https://atom.io/packages/dbg)
+For a list of features and all available keyboard shortcuts, please see [dbg](https://atom.io/packages/dbg) and [dbg-gdb](https://atom.io/packages/dbg-gdb)

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Creates a `dbgProvider` for GDB, see [basic dbgProvider  service description](ht
 > `gdb_executable` - *Optional*. The full command used to execute gdb (defaults to 'gdb')  
 > `gdb_arguments` - *Optional*. An array of extra arguments to pass to gdb (note that the arguments ['-quiet', '--interpreter=mi2'] are always included first)  
 > `gdb_commands` - *Optional*. An array of commands to pass to gdb, once active (these are executed last of all, but right before '-exec-run')  
-> `server_executable` - *Optional*. Starts a remote GDB server of your choice, ex: 'JLinkGDBServerCL')
-> `server_arguments` - *Optional*. An array of extra arguments to pass to the remote GDB server ex: ['-if', 'swd', '-device', 'nRF52832_xxAA'])
+> `server_executable` - *Optional*. Starts a remote GDB server of your choice, ex: 'JLinkGDBServerCL')  
+> `server_arguments` - *Optional*. An array of extra arguments to pass to the remote GDB server ex: ['-if', 'swd', '-device', 'nRF52832_xxAA'])  
 
 For a list of features and all available keyboard shortcuts, please see [dbg](https://atom.io/packages/dbg) and [dbg-gdb](https://atom.io/packages/dbg-gdb)
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ Creates a `dbgProvider` for GDB, see [basic dbgProvider  service description](ht
 > `server_arguments` - *Optional*. An array of extra arguments to pass to the remote GDB server ex: ['-if', 'swd', '-device', 'nRF52832_xxAA'])
 
 For a list of features and all available keyboard shortcuts, please see [dbg](https://atom.io/packages/dbg) and [dbg-gdb](https://atom.io/packages/dbg-gdb)
+
+## Example .atom-dbg.cson for nRF52 Embedded Target
+```
+"out\\current\\sys.axf":
+	debugger: "dbg-gdb"
+	gdb_executable: 'arm-none-eabi-gdb'
+	gdb_commands: ['target remote localhost:2331', 'monitor speed 1000',
+								 'monitor clrbp', 'monitor reset', 'monitor halt',
+								 'monitor regs', 'monitor flash breakpoints 1',
+								 'monitor semihosting enable', 'monitor semihosting IOClient 1',
+								 'monitor SWO DisableTarget 0xFFFFFFFF',
+								 'monitor SWO EnableTarget 0 0 0x1 0']
+	path: "out\\current\\sys.axf"
+	cwd: "out\\current"
+	server_executable: 'JLinkGDBServerCL'
+	server_arguments: ['-if', 'swd', '-device', 'nRF52832_xxAA',
+	                '-endian', 'little', '-speed', '1000', '-port',
+									'2331', '-swoport', '2332', '-telnetport',
+									'2333', '-vd', '-ir', '-localhostonly', '1',
+									'-singlerun', '-strict', '-timeout', '0']
+````

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -207,13 +207,6 @@ module.exports = DbgGdb =
 
 			@sendCommand '-gdb-set mi-async on'
 				.then => begin()
-				.catch =>
-					@sendCommand '-gdb-set target-async on'
-						.then => begin()
-						.catch (error) =>
-							if typeof error != 'string' then return
-							@handleMiError error, 'Unable to debug this with GDB'
-							@dbg.stop()
 
 		task.catch (error) =>
 			if typeof error != 'string' then return
@@ -269,9 +262,6 @@ module.exports = DbgGdb =
 					@showOutputPanelNext = false
 					@outputPanel.show()
 				@unseenOutputPanelContent = true
-				
-		else if process.platform=='win32'
-			options.gdb_commands = ([].concat options.gdb_commands||[]).concat 'set new-console on'
 
 		args = args.concat options.gdb_arguments||[]
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -205,8 +205,7 @@ module.exports = DbgGdb =
 
 							@dbg.stop()
 
-			@sendCommand '-gdb-set mi-async on'
-				.then => begin()
+			begin()
 
 		task.catch (error) =>
 			if typeof error != 'string' then return
@@ -264,6 +263,19 @@ module.exports = DbgGdb =
 				@unseenOutputPanelContent = true
 
 		args = args.concat options.gdb_arguments||[]
+
+		if options.server_executable
+			@process = new BufferedProcess
+				command: options.server_executable
+				args: options.server_arguments
+				options:
+					cwd: cwd
+				stdout: (data) =>
+					if @logToConsole then console.log 'dbg-gdb-server < ',data
+
+				exit: (data) =>
+					if @logToConsole then console.log 'dbg-gdb-server < ',data
+
 
 		@miEmitter = new Emitter()
 		@process = new BufferedProcess

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "dbg-gdb",
+  "name": "dbg-gdb-custom-server",
   "main": "./lib/main",
-  "version": "1.7.7",
-  "description": "An interactive GDB debugger for Atom",
+  "version": "0.0.1",
+  "description": "An interactive GDB debugger for Atom. Based on dbg-gdb, but provides more customization.",
   "keywords": [
     "gdb",
     "debugger",
@@ -17,7 +17,7 @@
     "assembly",
     "Ada"
   ],
-  "repository": "https://github.com/31i73/atom-dbg-gdb",
+  "repository": "https://github.com/msembinelli/atom-dbg-gdb-custom-server",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
@@ -31,7 +31,7 @@
   },
   "providedServices": {
     "dbgProvider": {
-      "description": "Provides a dbg gdb debugger",
+      "description": "Provides a dbg gdb debugger, and optionally starting a remote GDB debug server.",
       "versions": {
         "1.1.0": "provideDbgProvider"
       }


### PR DESCRIPTION
Provides more customizability by removing hardcoded commands:

- -gdb-set mi-async on and -gdb-set target-async on
- set new-console on

Create a new BufferedProcess to run a remote GDB debug server mainly used for embedded targets.
